### PR TITLE
Ensure 'addNote' element is not duplicated on prepend

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 
 
 ## Release 2.4
-- FIX : Ensure 'addNote' element is not duplicated on prepend - *16/05/2025* - 2.4.3
+- FIX DA026513 : Ensure 'addNote' element is not duplicated on prepend - *16/05/2025* - 2.4.3
     -Added a conditional check to avoid appending the '$a' element multiple times to the 'login_block_other' div. This change prevents duplicate elements when the page is rendered.
 - FIX: Position and date create postit - *26/02/2025* - 2.4.2
 - FIX: Compat v21  - *10/12/2024* - 2.4.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,8 @@
 
 
 ## Release 2.4
-
+- FIX : Ensure 'addNote' element is not duplicated on prepend - *16/05/2025* - 2.4.3
+    -Added a conditional check to avoid appending the '$a' element multiple times to the 'login_block_other' div. This change prevents duplicate elements when the page is rendered.
 - FIX: Position and date create postit - *26/02/2025* - 2.4.2
 - FIX: Compat v21  - *10/12/2024* - 2.4.1
 - FIX: Compat v20  : changed Dolibarr compatibility range to 16 min - 20 max - *18/07/2024* - 2.4.0

--- a/class/actions_postit.class.php
+++ b/class/actions_postit.class.php
@@ -105,9 +105,10 @@ class ActionsPostIt extends postit\RetroCompatCommonHookActions
 				if($user->hasRight('postit','allaction','write') || $user->hasRight('postit','myaction','write')) {
 
 				?>
-
-                $a = $('<?php echo $a ?>');
-                $('div.login_block_other').prepend($a);
+				if ($('#addNote').length === 0) {
+					$a = $('<?php echo $a ?>');
+					$('div.login_block_other').prepend($a);
+				}
 				<?php
 				}
 				?>

--- a/core/modules/modPostIt.class.php
+++ b/core/modules/modPostIt.class.php
@@ -73,7 +73,7 @@ class modPostIt extends DolibarrModules
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
 
-		$this->version = '2.4.2';
+		$this->version = '2.4.3';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';


### PR DESCRIPTION
Added a conditional check to avoid appending the '$a' element multiple times to the 'login_block_other' div. This change prevents duplicate elements when the page is rendered.